### PR TITLE
Cancel toastTimer

### DIFF
--- a/src/ionic-toast.provider.js
+++ b/src/ionic-toast.provider.js
@@ -72,7 +72,7 @@ angular.module('ionic-toast.provider', [])
 
           toggleDisplayOfToast('block', 1, function () {
             if (isSticky)  return;
-
+            $timeout.cancel(toastTimer);
             toastTimer = $timeout(function () {
               $scope.hideToast();
             }, duration);


### PR DESCRIPTION
If you don't cancel the toastTimer, and you click several times, the last toast duration is equal to the duration you set less the duration since the first click.